### PR TITLE
Bunch of fixes

### DIFF
--- a/src/frontend/cxx-overload.c
+++ b/src/frontend/cxx-overload.c
@@ -187,6 +187,12 @@ static implicit_conversion_sequence_t ics_make_user_defined_using_conversor(type
     if (symbol_entity_specs_get_is_constructor(conversor))
     {
         type_t* conversion_source_type = function_type_get_parameter_type_num(conversor->type_information, 0);
+        // Ellipsis is special and can only happen here, normalize it to orig
+        // so standard_conversion_between_types_for_overload returns an
+        // identity.
+        if (is_ellipsis_type(conversion_source_type))
+            conversion_source_type = orig;
+
         type_t* class_type = symbol_entity_specs_get_class_type(conversor);
 
         standard_conversion_t first_sc;

--- a/src/frontend/cxx03.y.in
+++ b/src/frontend/cxx03.y.in
@@ -568,6 +568,7 @@ void yyerror(AST* parsed_tree UNUSED_PARAMETER, const char* c);
 %type<ast> template_logical_and_expression
 %type<ast> template_logical_or_expression
 %type<ast> template_parameter
+%type<ast> template_parameter_declaration
 %type<ast> template_parameter_list
 %type<ast> template_relational_expression
 %type<ast> template_shift_expression
@@ -6123,9 +6124,64 @@ template_parameter : type_parameter %dprec 2
 {
 	$$ = $1;
 }
-| parameter_declaration %dprec 1
+| template_parameter_declaration %dprec 1
 {
 	$$ = $1;
+}
+;
+
+template_parameter_declaration : decl_specifier_seq_0 %merge<ambiguityHandler>
+{
+   $$ = ASTMake3(AST_PARAMETER_DECL, $1, NULL, NULL, ast_get_locus($1), NULL);
+}
+| decl_specifier_seq_ended_with_named_type_spec %merge<ambiguityHandler>
+{
+   $$ = ASTMake3(AST_PARAMETER_DECL, $1, NULL, NULL, ast_get_locus($1), NULL);
+}
+// --
+| decl_specifier_seq_0 '=' template_assignment_expression gcc_attributes_opt %merge<ambiguityHandler>
+{
+   $$ = ASTMake4(AST_PARAMETER_DECL, $1, NULL, $3, $4, ast_get_locus($1), NULL);
+}
+| decl_specifier_seq_ended_with_named_type_spec '=' template_assignment_expression gcc_attributes_opt %merge<ambiguityHandler>
+{
+   $$ = ASTMake4(AST_PARAMETER_DECL, $1, NULL, $3, $4, ast_get_locus($1), NULL);
+}
+// --
+| decl_specifier_seq_0 nonabstract_declarator_not_started_with_attributes gcc_attributes_opt %merge<ambiguityHandler>
+{
+	$$ = ASTMake4(AST_PARAMETER_DECL, $1, $2, NULL, $3, ast_get_locus($1), NULL);
+}
+| decl_specifier_seq_ended_with_named_type_spec nonglobal_nonabstract_declarator_not_started_with_attributes gcc_attributes_opt %merge<ambiguityHandler>
+{
+	$$ = ASTMake4(AST_PARAMETER_DECL, $1, $2, NULL, $3, ast_get_locus($1), NULL);
+}
+// --
+| decl_specifier_seq_0 nonabstract_declarator_not_started_with_attributes gcc_attributes_opt '=' template_assignment_expression  %merge<ambiguityHandler>
+{
+	$$ = ASTMake4(AST_PARAMETER_DECL, $1, $2, $5, $3, ast_get_locus($1), NULL);
+}
+| decl_specifier_seq_ended_with_named_type_spec nonglobal_nonabstract_declarator_not_started_with_attributes gcc_attributes_opt '=' template_assignment_expression  %merge<ambiguityHandler>
+{
+	$$ = ASTMake4(AST_PARAMETER_DECL, $1, $2, $5, $3, ast_get_locus($1), NULL);
+}
+// --
+| decl_specifier_seq_0 abstract_declarator_not_started_with_attributes gcc_attributes_opt %merge<ambiguityHandler>
+{
+	$$ = ASTMake4(AST_PARAMETER_DECL, $1, $2, NULL, $3, ast_get_locus($1), NULL);
+}
+| decl_specifier_seq_ended_with_named_type_spec nonglobal_abstract_declarator_not_started_with_attributes gcc_attributes_opt %merge<ambiguityHandler>
+{
+	$$ = ASTMake4(AST_PARAMETER_DECL, $1, $2, NULL, $3, ast_get_locus($1), NULL);
+}
+// --
+| decl_specifier_seq_0 abstract_declarator_not_started_with_attributes gcc_attributes_opt '=' template_assignment_expression %merge<ambiguityHandler>
+{
+	$$ = ASTMake4(AST_PARAMETER_DECL, $1, $2, $5, $3, ast_get_locus($1), NULL);
+}
+| decl_specifier_seq_ended_with_named_type_spec nonglobal_abstract_declarator_not_started_with_attributes gcc_attributes_opt '=' template_assignment_expression %merge<ambiguityHandler>
+{
+	$$ = ASTMake4(AST_PARAMETER_DECL, $1, $2, $5, $3, ast_get_locus($1), NULL);
 }
 ;
 

--- a/tests/02_typecalc_cxx.dg/failure_051.cpp
+++ b/tests/02_typecalc_cxx.dg/failure_051.cpp
@@ -1,0 +1,20 @@
+/*
+<testinfo>
+test_generator=config/mercurium-fe-only
+test_compile_fail=yes
+</testinfo>
+*/
+
+struct A
+{
+    A(float);
+};
+
+struct B
+{
+    B(A);
+    B(...);
+    B(const B&);
+};
+
+B b(1.2f);

--- a/tests/02_typecalc_cxx11.dg/success_221.cpp
+++ b/tests/02_typecalc_cxx11.dg/success_221.cpp
@@ -1,0 +1,12 @@
+/*
+<testinfo>
+test_generator="config/mercurium-cxx11"
+</testinfo>
+*/
+template < typename T>
+class List { };
+
+typedef int K;
+
+template < int S = 0 >
+List< K > foo();

--- a/tests/06_run_cxx.dg/success_003.cpp
+++ b/tests/06_run_cxx.dg/success_003.cpp
@@ -32,6 +32,14 @@ test_generator=config/mercurium-run
 </testinfo>
 */
 
+#if __GNUC__ >= 6
+
+int main()
+{
+}
+
+#else
+
 #include<assert.h>
 
 class C
@@ -60,3 +68,5 @@ int main()
     f<int>(2, c);
     assert(c.get_x() != 3);
 }
+
+#endif

--- a/tests/config/mercurium.in
+++ b/tests/config/mercurium.in
@@ -6,7 +6,7 @@ source @abs_top_builddir@/tests/config/mercurium-libraries
 cat <<EOF
 MCXX="@abs_top_builddir@/src/driver/plaincxx --output-dir=@abs_top_builddir@/tests --config-dir=@abs_top_builddir@/config --verbose"
 test_CC="\${MCXX} --profile=plaincc"
-test_CXX="\${MCXX} --profile=plaincxx"
+test_CXX="\${MCXX} --profile=plaincxx -std=c++03"
 test_FC="\${MCXX} --profile=plainfc"
 
 if [ "$test_nolink" == "no" -o "$1" = "run" ];


### PR DESCRIPTION
- Pass -std=c++03 to C++ tests as GCC 6 will default to C++14
- Remove an arguable test that is not valid any more in GCC 6
- Fix a failure during a user-defined conversion because the target of the conversion was actually an ellipsis
- Fix a parsing ambiguity in a non type template-argument