### PR TITLE
Fix wrong conversion in assignment

### DIFF
--- a/src/frontend/fortran/fortran03-exprtype.c
+++ b/src/frontend/fortran/fortran03-exprtype.c
@@ -4830,7 +4830,7 @@ static void check_assignment(AST expr, const decl_context_t* decl_context, nodec
                     get_unqualified_type(nodecl_get_type(nodecl_rvalue))))
         {
             nodecl_rvalue = nodecl_make_conversion(nodecl_rvalue, 
-                    lvalue_type,
+                    no_ref(lvalue_type),
                     nodecl_get_locus(nodecl_rvalue));
         }
 


### PR DESCRIPTION
The value of the right hand side of an assignment should be converted to
a value of the left hand side, not to a location like the left hand
side.

For instance, in the following code

```
INTEGER :: A
REAL :: B
A = B
```

`B` happens to be converted to `(lvalue) reference to signed int` instead of just to `signed int`.