### PR TITLE
Add a mechanism to update global test results

### DIFF
--- a/tests/config/bets.in
+++ b/tests/config/bets.in
@@ -150,16 +150,16 @@ passfail ()
      else
        filtered_message "${YELLOW}passed (faulty)${NORMAL}"
        log "passed (faulty)"
-       let faulty=faulty+1
+       let run_faulty=run_faulty+1
        # Note in jUnit output these tests are not flagged in any special way!
      fi
-     let pass=pass+1
+     let run_pass=run_pass+1
    else
      if [ ! "$test_ignore_fail" ]; then
        filtered_message "${RED}failed${NORMAL}!"
        log "failed!"
        junit_log "<error />"
-       let fail=fail+1
+       let run_fail=run_fail+1
      else
        # Note in jUnit output these tests are not flagged in any special way!
        filtered_message "${YELLOW}failed (ignored)${NORMAL}!"
@@ -571,6 +571,10 @@ run_test ()
    local name=$(basename ${source%.*})
    local srcdir=$(pwd)
 
+   run_pass=0
+   run_fail=0
+   run_faulty=0
+
    if [ "$compressed" = compressed ];
    then
        local uncompressed_name=${source%.*}
@@ -744,6 +748,9 @@ run_test ()
                 done
               fi
            done
+
+           # Allow results to go out the subshell
+           output_results
        )
    done
 
@@ -758,6 +765,10 @@ run_package()
 {
     local name=$1
     local compressed=$2
+
+    run_pass=0
+    run_fail=0
+    run_faulty=0
 
     if [ "$compressed" = compressed ]; then
         local file=$name
@@ -787,11 +798,44 @@ run_package()
         log "***Removing uncompressed package directory '$tmpdir/$name'"
         rm -rf "$tmpdir/$name"
     fi
+
+    # This is not a subshell but it should behave like run_test
+    output_results
+    unset run_pass
+    unset run_fail
+    unset run_faulty
+}
+
+init_results()
+{
+    cat /dev/null > $runresults
+}
+
+output_results()
+{
+    echo $run_pass $run_fail $run_faulty >> $runresults
+}
+
+update_results()
+{
+   # Read output values and update the global counters
+   local run_pass=0
+   local run_fail=0
+   local run_faulty=0
+   while read run_pass run_fail run_faulty;
+   do
+     let pass=pass+run_pass
+     let fail=fail+run_fail
+     let faulty=faulty+run_faulty
+   done < $runresults
 }
 
 run_file()
 {
    local file=$1
+
+   init_results
+
    case $file in
      *.c)
        run_test $file c
@@ -812,6 +856,8 @@ run_file()
        run_package $file compressed
        ;;
    esac
+
+   update_results
 }
 
 run_dir()
@@ -876,6 +922,7 @@ do_run ()
    declare -r tmpdir=$(mktemp -d)
    export TMPDIR=$tmpdir
    declare -r tmpfile=$(mktemp)
+   declare -r runresults=$(mktemp)
    local old_dir=""
    local ret=0
 
@@ -919,6 +966,7 @@ EOF
    
    #clean-up
    rm -fr $tmpdir
+   rm -f $runresults
 
    # End junit log
    cat >> $junit_logfile << EOF


### PR DESCRIPTION
Commit 953888db6a55cce0e2fb020d3935e1a153337aea made bets to always
report no tests run: subshells cannot update their environment.

A way to fix this is making the subshells output the current results
and aggregate them in run_file.