### PR TITLE
Fix handling of array-spec in the TARGET statement

### DIFF
--- a/tests/01_fortran.dg/failure_target_01.f90
+++ b/tests/01_fortran.dg/failure_target_01.f90
@@ -1,0 +1,9 @@
+! <testinfo>
+! test_generator=config/mercurium-fortran
+! test_compile_fail=yes
+! </testinfo>
+PROGRAM MAIN
+    IMPLICIT NONE
+    TARGET :: W(4)
+
+END PROGRAM MAIN

--- a/tests/01_fortran.dg/failure_target_02.f90
+++ b/tests/01_fortran.dg/failure_target_02.f90
@@ -1,0 +1,9 @@
+! <testinfo>
+! test_generator=config/mercurium-fortran
+! test_compile_fail=yes
+! </testinfo>
+PROGRAM MAIN
+    IMPLICIT NONE
+    INTEGER :: W(4)
+    TARGET :: W(5)
+END PROGRAM MAIN

--- a/tests/01_fortran.dg/success_target_01.f90
+++ b/tests/01_fortran.dg/success_target_01.f90
@@ -1,0 +1,13 @@
+! <testinfo>
+! test_generator=config/mercurium-fortran
+! </testinfo>
+PROGRAM MAIN
+    IMPLICIT NONE
+    INTEGER  :: X, Y, Z
+    TARGET :: X(10)
+    TARGET :: Y(10), Z(20)
+
+    X(1) = 2
+    Y(3) = 4
+    Z(5) = 6
+END PROGRAM MAIN


### PR DESCRIPTION
The existing code used the wrong tree when the target entity
contained an array-specifier.

This fixes #5