### PR TITLE
Fix use after-free

### DIFF
--- a/src/tl/analysis/common/tl-induction-variables-data.cpp
+++ b/src/tl/analysis/common/tl-induction-variables-data.cpp
@@ -55,7 +55,7 @@ namespace Utils {
         _var = var;
     }
 
-    NodeclSet InductionVar::get_lb() const
+    const NodeclSet &InductionVar::get_lb() const
     {
         return _lb;
     }
@@ -71,7 +71,7 @@ namespace Utils {
         _lb = lb;
     }
 
-    NodeclSet InductionVar::get_ub() const
+    const NodeclSet &InductionVar::get_ub() const
     {
         return _ub;
     }

--- a/src/tl/analysis/common/tl-induction-variables-data.hpp
+++ b/src/tl/analysis/common/tl-induction-variables-data.hpp
@@ -70,11 +70,11 @@ namespace Utils {
         NBase get_variable() const;
         void set_variable(const NBase& s);
 
-        NodeclSet get_lb() const;
+        const NodeclSet &get_lb() const;
         void set_lb(const NBase& lb);
         void set_lb(const NodeclSet& lb);
 
-        NodeclSet get_ub() const;
+        const NodeclSet &get_ub() const;
         void set_ub(const NBase& ub);
         void set_ub(const NodeclSet& ub);
 


### PR DESCRIPTION
In `tl-analysis-check-phase.cpp` we see (and similarly for `get_ub`)

```cpp
const Nodecl::NodeclBase& assert_lb = *(c_it->get_lb().begin());
```
but unfortunately this fails to work as `get_lb` and `get_ub` are defined like this
```cpp
NodeclSet InductionVar::get_ub() const
```
Here the set returned is destroyed at the end of the initialization so its internal element (accessible by `begin()`) is destroyed as well.

As copying the set may not make sense, just return a const reference to it, so its internal object will survive as no copy happens.

Just to make a bit clearer what is happening here, the situation is in practice the same as follows;

- This first case below is correct because C++ extends the lifetime of the temporary returned by `foo()` to be the same as the scope of `cref`.
```cpp
std::vector<T> foo();
const std::vector<T>& cref = foo();
```
- This second cause, though, is not correct. The temporary is destroyed even if we are binding to one object of it (there would not be way to tell this).
```cpp
std::vector<T> foo();
const T &ci = *(foo().begin());
```
The temporary tmp returned by `foo()` is destroyed at the ";" so the iterator returned by `tmp.begin()` becomes invalid and then what was bound to the reference is invalid as well (we're binding to what is **inside** the container).

This problem was flagged by `valgrind --tool=memcheck`