### PR TITLE
Add generator to test

### DIFF
--- a/tests/02_typecalc_cxx11.dg/success_237.cpp
+++ b/tests/02_typecalc_cxx11.dg/success_237.cpp
@@ -1,3 +1,10 @@
+/*
+<testinfo>
+test_generator="config/mercurium-cxx11"
+test_nolink=yes
+</testinfo>
+*/
+
 template < int X, typename T>
 struct A
 {


### PR DESCRIPTION
In 56725e4d52 the test was added without generator.

This is currently not an error but it may be a good idea to change bets
so it is, otherwise the test is ignored.

Luckily the test is still passing :)