### PR TITLE
Make C_NULL_PTR a constant and fix a problem with array initialization

### DIFF
--- a/src/frontend/fortran/fortran03-exprtype.c
+++ b/src/frontend/fortran/fortran03-exprtype.c
@@ -5119,7 +5119,6 @@ static void cast_initialization(
             {
                 // We do not expand the full array to a tree, just we keep the original simple tree
                 // and modify the const value of the scalar
-                *nodecl_output = const_value_to_nodecl_with_basic_type(val, rank0_type);
                 nodecl_set_constant(*nodecl_output, *casted_const);
             }
         }

--- a/src/frontend/fortran/fortran03-intrinsics.c
+++ b/src/frontend/fortran/fortran03-intrinsics.c
@@ -7259,7 +7259,10 @@ static void fortran_init_intrinsic_module_iso_c_binding(const decl_context_t* de
             UNIQUESTR_LITERAL("c_null_ptr"));
     c_null_ptr->locus = locus;
     c_null_ptr->kind = SK_VARIABLE;
-    c_null_ptr->type_information = get_user_defined_type(c_ptr);
+    c_null_ptr->type_information = get_const_qualified_type(get_user_defined_type(c_ptr));
+    c_null_ptr->value = const_value_to_nodecl(
+            const_value_make_struct(0, NULL,
+                get_user_defined_type(c_ptr)));
     symbol_entity_specs_set_in_module(c_null_ptr, iso_c_binding);
     symbol_entity_specs_set_access(c_null_ptr, AS_PUBLIC);
     symbol_entity_specs_add_related_symbols(iso_c_binding,

--- a/tests/01_fortran.dg/success_iso_c_binding_13.f90
+++ b/tests/01_fortran.dg/success_iso_c_binding_13.f90
@@ -1,0 +1,19 @@
+! <testinfo>
+! test_generator=config/mercurium-fortran
+! </testinfo>
+
+SUBROUTINE FOO
+    USE, INTRINSIC :: ISO_C_BINDING
+    TYPE(C_PTR), SAVE :: A = C_NULL_PTR
+
+    IF (C_ASSOCIATED(A)) STOP 1
+END SUBROUTINE FOO
+
+SUBROUTINE FOO2(I)
+    USE, INTRINSIC :: ISO_C_BINDING
+    IMPLICIT NONE
+    INTEGER :: I
+    TYPE(C_PTR), SAVE :: A(2) = C_NULL_PTR
+
+    IF (C_ASSOCIATED(A(I))) STOP 1
+END SUBROUTINE FOO2


### PR DESCRIPTION
When making C_NULL_PTR a constant we discovered that we assume it will
be possible to update the expression of a scalar that initializes an
array to a tree derived from the constant expression.

Don't do this as it is not always possible (we are not doing for
arrays whose size is not known so we shouldn't be losing much).