### PR TITLE
Fix registering of specific names of generic intrinsics

### DIFF
--- a/src/frontend/fortran/fortran03-intrinsics.c
+++ b/src/frontend/fortran/fortran03-intrinsics.c
@@ -1147,10 +1147,7 @@ static scope_entry_t* get_intrinsic_symbol_(
         char is_inquiry UNUSED_PARAMETER)
 {
     ERROR_CONDITION(result_type == NULL, "This should be void", 0);
-
-    if (generic_symbol != NULL
-            && generic_symbol->symbol_name != NULL)
-        name = generic_symbol->symbol_name;
+    ERROR_CONDITION(name == NULL, "name cannot be null", 0);
 
     int i;
     for (i = 0; i < num_types; i++)
@@ -1499,6 +1496,10 @@ static scope_entry_t* register_specific_intrinsic_name(
     if (strcasecmp(generic_name, specific_name) == 0)
     {
         // If the name is the same, mark it as the specific interface of this intrinsic
+        ERROR_CONDITION(
+            symbol_entity_specs_get_specific_intrinsic(generic_entry) != NULL,
+            "Overwriting the specific intrinsic of generic name '%s'",
+            generic_entry->symbol_name);
         symbol_entity_specs_set_specific_intrinsic(generic_entry, specific_entry);
     }
     else
@@ -1531,15 +1532,10 @@ static scope_entry_t* register_specific_intrinsic_name(
                 result_type,
                 real_num_parameters, param_types,
                 generic_entry->decl_context,
-                symbol_entity_specs_get_is_elemental(generic_entry),
-                symbol_entity_specs_get_is_pure(generic_entry),
+                symbol_entity_specs_get_is_elemental(specific_entry),
+                symbol_entity_specs_get_is_pure(specific_entry),
                 /* is_transformational */ 0,
                 /* is_inquiry */ 0);
-
-        // Note that get_intrinsic_symbol_ uses the name in generic_entry
-        // if it is not NULL, and here it will never be null, so overwrite
-        // the name now
-        new_specific_entry->symbol_name = uniquestr(specific_name);
 
         // Add the keywords that are non null
         for (i = 0; i < MAX_SPECIFIC_PARAMETERS; i++)

--- a/tests/01_fortran.dg/success_intrinsics_50.f90
+++ b/tests/01_fortran.dg/success_intrinsics_50.f90
@@ -1,0 +1,38 @@
+! <testinfo>
+! test_generator=config/mercurium-fortran
+! </testinfo>
+SUBROUTINE FOO(I4, R4, R8, C4, C8)
+    IMPLICIT NONE
+    INTEGER(KIND=4) :: I4(:)
+    REAL(KIND=4) :: R4(:)
+    REAL(KIND=8) :: R8(:)
+    COMPLEX(KIND=4) :: C4(:)
+    COMPLEX(KIND=8) :: C8(:)
+
+    INTERFACE CHECK_ARRAY
+        SUBROUTINE CHECK_ARRAY_R4(R)
+            REAL(KIND=4) :: R(:)
+        END SUBROUTINE CHECK_ARRAY_R4
+
+        SUBROUTINE CHECK_ARRAY_R8(R)
+            REAL(KIND=8) :: R(:)
+        END SUBROUTINE CHECK_ARRAY_R8
+
+        SUBROUTINE CHECK_ARRAY_I4(R)
+            INTEGER(KIND=4) :: R(:)
+        END SUBROUTINE CHECK_ARRAY_I4
+    END INTERFACE
+
+    ! Generic
+    CALL CHECK_ARRAY(ABS(R4))
+    CALL CHECK_ARRAY(ABS(R8))
+
+    ! Specific
+    CALL CHECK_ARRAY(DABS(R8))
+    CALL CHECK_ARRAY(CABS(C4))
+    CALL CHECK_ARRAY(IABS(I4))
+
+    ! Specific (legacy G77)
+    CALL CHECK_ARRAY(ZABS(C8))
+    CALL CHECK_ARRAY(CDABS(C8))
+END SUBROUTINE FOO


### PR DESCRIPTION
A few intrinsics have specific names that correspond to particular
instances of the intrinsics themselves. During initialization of
the intrinsics we create them as instances of their generic intrinsics.

For specific intrinsics with the same name as the generic one we do
this correctly but for those with different names we were doing it wrong.

First looks like there is no reason to overwrite the name used to
register the specific name with the name of the generic symbol,
so just don't overwrite it and use the given name.

Second the generic symbol does not know whether it will be elemental
or not. This is known at the point of creating the specific function.
We can discuss if this is sensible and we may have to fix this if
at some point the language tries to reason at the generic level. For now
it does not do this, so just propagate the correct attributes from
the specific intrinsic.

With this change we can compile specfem3d 7.0.0 with plainfc
using OpenMPI (with minor changes in parallel.f90 to use mpif.h
instead of the mpi module of OpenMPI itself because we cannot use it yet).