### PR TITLE
Fix test with invalid syntax

### DIFF
--- a/tests/07_phases_ompss.dg/fortran/success_task_28.f90
+++ b/tests/07_phases_ompss.dg/fortran/success_task_28.f90
@@ -5,6 +5,7 @@
 
 SUBROUTINE FOO(N)
     IMPLICIT NONE
+    INTEGER :: N
     INTEGER :: A(N)
     INTEGER :: B(N)
 


### PR DESCRIPTION
`N` does not have type-spec, so add the obvious one which is `INTEGER`.