### PR TITLE
Implement deferred character length using a descriptor array

### DIFF
--- a/src/frontend/fortran/fortran03-buildscope.c
+++ b/src/frontend/fortran/fortran03-buildscope.c
@@ -931,38 +931,89 @@ static delayed_character_length_t* delayed_character_length_new(
     return result;
 }
 
-static void delayed_compute_character_length(void *info, nodecl_t* nodecl_output UNUSED_PARAMETER)
+static void delayed_compute_character_length(
+    void *info, nodecl_t *nodecl_output UNUSED_PARAMETER)
 {
-    delayed_character_length_t* data = (delayed_character_length_t*)info;
+    delayed_character_length_t *data = (delayed_character_length_t *)info;
 
     nodecl_t nodecl_len = nodecl_null();
-    fortran_check_expression(data->length, data->decl_context, &nodecl_len);
+    char is_star = 0;
+    char is_colon = 0;
 
-    if (nodecl_is_err_expr(nodecl_len))
+    if (ASTKind(data->length) == AST_SYMBOL
+        && strcmp(ASTText(data->length), "*") == 0)
+    {
+        is_star = 1;
+    }
+    else if (ASTKind(data->length) == AST_SYMBOL
+             && strcmp(ASTText(data->length), ":") == 0)
+    {
+        is_colon = 1;
+    }
+    else
+    {
+        fortran_check_expression(data->length, data->decl_context, &nodecl_len);
+    }
+
+    if (is_star || is_colon)
     {
         int i;
         for (i = 0; i < data->num_symbols; i++)
         {
-            data->symbols[i]->type_information = get_error_type();
+            scope_entry_t *current_symbol = data->symbols[i];
+            if (is_star)
+            {
+                // FIXME - We should check this is either a DUMMY or a PARAMETER of CHARACTER(*)
+            }
+            else if (is_colon)
+            {
+                // FIXME - We should check this is either an ALLOCATABLE or a CHARACTER
+
+                // Replace the array with one with descriptor.
+                type_t *updated_char_type = get_array_type_bounds_with_descriptor(
+                        array_type_get_element_type(data->character_type),
+                        nodecl_null(),
+                        nodecl_null(),
+                        current_symbol->decl_context);
+
+                current_symbol->type_information = delayed_character_length_update_type(
+                    current_symbol->type_information, updated_char_type);
+            }
+            else
+            {
+                internal_error("Code unreachable", 0);
+            }
+        }
+    }
+    else if (nodecl_is_err_expr(nodecl_len))
+    {
+        int i;
+        for (i = 0; i < data->num_symbols; i++)
+        {
+            scope_entry_t *current_symbol = data->symbols[i];
+            current_symbol->type_information = get_error_type();
         }
     }
     else
     {
         nodecl_len = fortran_expression_as_value(nodecl_len);
         nodecl_t lower_bound = nodecl_make_integer_literal(
-                get_signed_int_type(),
-                const_value_get_one(type_get_size(get_signed_int_type()), 1),
-                nodecl_get_locus(nodecl_len));
-        type_t* updated_char_type = get_array_type_bounds(
-                array_type_get_element_type(data->character_type),
-                lower_bound, nodecl_len, data->decl_context);
+            get_signed_int_type(),
+            const_value_get_one(type_get_size(get_signed_int_type()), 1),
+            nodecl_get_locus(nodecl_len));
+        type_t *updated_char_type = get_array_type_bounds(
+            array_type_get_element_type(data->character_type),
+            lower_bound,
+            nodecl_len,
+            data->decl_context);
 
         int i;
         for (i = 0; i < data->num_symbols; i++)
         {
-            data->symbols[i]->type_information = delayed_character_length_update_type(
-                    data->symbols[i]->type_information,
-                    updated_char_type);
+            scope_entry_t *current_symbol = data->symbols[i];
+            current_symbol->type_information
+                = delayed_character_length_update_type(
+                    current_symbol->type_information, updated_char_type);
         }
     }
 
@@ -3175,12 +3226,6 @@ static type_t* fortran_gather_type_from_declaration_type_spec_(AST a,
                             const_value_get_one(type_get_size(get_signed_int_type()), 1),
                             nodecl_get_locus(nodecl_len));
                     result = get_array_type_bounds(result, lower_bound, nodecl_len, decl_context);
-                }
-                else if (ASTKind(len) == AST_SYMBOL
-                        && strcmp(ASTText(len), "*") == 0)
-                {
-                    // undefined length
-                    result = get_array_type(result, nodecl_null(), decl_context);
                 }
                 else
                 {

--- a/src/frontend/fortran/fortran03-buildscope.c
+++ b/src/frontend/fortran/fortran03-buildscope.c
@@ -967,7 +967,7 @@ static void delayed_compute_character_length(
             }
             else if (is_colon)
             {
-                // FIXME - We should check this is either an ALLOCATABLE or a CHARACTER
+                // FIXME - We should check this is either an ALLOCATABLE or a POINTER
 
                 // Replace the array with one with descriptor.
                 type_t *updated_char_type = get_array_type_bounds_with_descriptor(

--- a/src/tl/codegen/base/fortran/codegen-fortran.cpp
+++ b/src/tl/codegen/base/fortran/codegen-fortran.cpp
@@ -5946,6 +5946,10 @@ OPERATOR_TABLE
                                 this->codegen_to_str(string_size, string_size.retrieve_context()))
                         << ")";
             }
+            else if (array_type_with_descriptor(t.get_internal_type()))
+            {
+                ss << "CHARACTER(LEN=:)";
+            }
             else
             {
                 if (!state.emit_interoperable_types)

--- a/tests/01_fortran.dg/success_character_length_05.f90
+++ b/tests/01_fortran.dg/success_character_length_05.f90
@@ -1,0 +1,30 @@
+! <testinfo>
+! test_generator=config/mercurium-fortran
+! </testinfo>
+MODULE MOO
+    IMPLICIT NONE
+CONTAINS
+    SUBROUTINE SUB(A, C, PC)
+        IMPLICIT NONE
+        CHARACTER(LEN=*), ALLOCATABLE :: A
+        CHARACTER(LEN=:), ALLOCATABLE :: C
+        CHARACTER(LEN=:), POINTER :: PC
+    END SUBROUTINE SUB
+
+    SUBROUTINE FOO()
+        IMPLICIT NONE
+
+        CHARACTER(LEN=10), ALLOCATABLE :: A
+        CHARACTER(LEN=:), ALLOCATABLE :: C
+        CHARACTER(LEN=:), POINTER :: PC
+
+        CHARACTER(LEN=100) :: SRC
+
+        ALLOCATE(A)
+        ALLOCATE(C, SOURCE=SRC)
+        ALLOCATE(C, SOURCE=SRC)
+        ALLOCATE(PC, SOURCE=SRC)
+
+        CALL SUB(A, C, PC)
+    END SUBROUTINE FOO
+END MODULE MOO


### PR DESCRIPTION
This is only useful for `CHARACTER(LEN=:)`

In Fortran we implement `CHARACTER` scalar type using a C array of characters. That array, which is not considered a Fortran array, never used to have a descriptor. Now that `LEN` can be deferred, we
will represent this using a descriptor at that array.

Note that the change also introduces a couple of FIXMEs just to remind us that `LEN=:` is only valid in some cases.