### PR TITLE
Fix decltype for symbols and class member accesses

### DIFF
--- a/src/frontend/cxx-exprtype.c
+++ b/src/frontend/cxx-exprtype.c
@@ -22581,10 +22581,14 @@ type_t* compute_type_of_decltype_nodecl(nodecl_t nodecl_expr, const decl_context
 
     computed_type = clear_special_expr_type_variants(computed_type);
 
-    if (nodecl_get_kind(nodecl_expr) == NODECL_SYMBOL
-            || nodecl_get_kind(nodecl_expr) == NODECL_CLASS_MEMBER_ACCESS)
+    if (nodecl_get_kind(nodecl_expr) == NODECL_SYMBOL)
     {
-        return no_ref(computed_type);
+        return nodecl_get_symbol(nodecl_expr)->type_information;
+    }
+    else if (nodecl_get_kind(nodecl_expr) == NODECL_CLASS_MEMBER_ACCESS)
+    {
+        return nodecl_get_symbol(nodecl_get_child(nodecl_expr, 1))
+            ->type_information;
     }
     else
     {

--- a/tests/02_typecalc_cxx11.dg/success_254.cpp
+++ b/tests/02_typecalc_cxx11.dg/success_254.cpp
@@ -1,0 +1,33 @@
+/*
+<testinfo>
+test_generator="config/mercurium-cxx11"
+test_nolink=yes
+</testinfo>
+*/
+
+template <typename T, typename Q>
+struct SameType;
+
+template <typename T>
+struct SameType<T, T> { };
+
+struct B
+{
+    int x;
+    static int y;
+};
+
+void foo(const B& rb, const B *pb)
+{
+    SameType<int, decltype(rb.x)>();
+    SameType<int, decltype(pb->x)>();
+
+    SameType<const int&, decltype((rb.x))>();
+    SameType<const int&, decltype((pb->x))>();
+
+    SameType<int, decltype(rb.y)>();
+    SameType<int, decltype(pb->y)>();
+
+    SameType<int &, decltype((rb.y))>();
+    SameType<int &, decltype((pb->y))>();
+}


### PR DESCRIPTION
The standard says that we have to use the type of the declaration.