### PR TITLE
fix_iconv_link: add $LIBICONV to front library compilation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -341,6 +341,7 @@ src_frontend_libmcxx_la_LIBADD = \
 					./lib/libmcxx-utils.la \
                     ./src/frontend/libmcxx-process.la \
                     ./src/frontend/libgccbuiltins.la \
+					$(LIBICONV) \
 					$(quadmath_LIBS) \
 					$(END)
 
@@ -2506,7 +2507,7 @@ src_tl_ompss_oss_lint_libtloss_lint_la_CXXFLAGS = $(phases_cxxflags) \
                           -I $(top_srcdir)/src/tl/analysis/tdg \
                           -I $(top_srcdir)/src/tl/analysis/interface \
                           $(END)
-                          
+
 
 src_tl_ompss_oss_lint_libtloss_lint_la_LDFLAGS = $(phases_ldflags)
 src_tl_ompss_oss_lint_libtloss_lint_la_LIBADD = $(phases_libadd) \
@@ -3524,7 +3525,7 @@ BUILT_SOURCES += $(INSTALL_CONFIG_FILES) $(INSTALL_SCRIPT_COMPILER_NAMES)
 # Generates configs
 config/% : config/template.$(notdir %) Makefile
 	$(AM_V_GEN)( $(config_edit) "$<" > "$@.tmp"; mv -f "$@.tmp" "$@" )
- 
+
 config-install-data-hook: remove-old-profiles
 
 EXTRA_DIST += \


### PR DESCRIPTION
This fixes issues when the configure script founds an "explicit" libiconv (not the iconv implementation of libc), e.g., installed from https://www.gnu.org/software/libiconv/. In particular, it should solve bsc-pm#35 and bsc-pm#34